### PR TITLE
Changes to `behind-pref` and policy

### DIFF
--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -75,7 +75,7 @@ and disable (but not delete) `release60`, `beta61`, and `nightly62`.
 
 #### ESR
 
-For tracking the feature in ESR, we create a `behind-pref-esr` status flag. It will be kept up with the values of the current and previous ESR releases. 
+For tracking the feature in ESR, we create a `behind-pref-esr` status flag. It will be kept up with the values of the current,  previous, and next ESR releases. 
 
 _Example_
 
@@ -83,6 +83,7 @@ _Example_
 - `off`
 - `esr52`
 - `esr60`
+- `esr72`
 
 ### Example
 
@@ -118,9 +119,9 @@ Once the feature has been verfied by QA then:
 
 The feature now *rides the trains* to release. The bug is then considered completed. 
 
-If it's decided to hold the feature out of the next release and let Beta users try it out, then the `behind-pref` flag is set to `betaNN` where NN is the next beta. Once the decision is made to let the feature ride the trains, then it is updated to `releaseNN`.
+If it's decided to hold the feature out of the next release and let Beta users try it out, then the `behind-pref` flag is set to `betaNN` where NN is the next beta. Once the decision is made to let the feature ride the trains, then it is updated to `releaseNN` where NN is the target release.
 
-When the next ESR is released, the `behind-pref-esr` field should be set to the version where it was relased. 
+When the feature is merged to ESR the `behind-pref-esr` field should be set to the version where it will be relased. 
 
 ### Questions 
 
@@ -140,11 +141,11 @@ On merge day, the `behind-pref` flag would retain it's earlier value, and remain
 
 #### What if I want to enable parts of my feature in Nightly?
 
-If your feature is incomplete, but some functionality is avalable, then mark `behind-pref` as `nightlyNN+2`. Do not request `qe-verify` until the feature is complete.
+If your feature is incomplete, but some functionality is avalable, then mark `behind-pref` as `nightlyNN` where NN is the current nighty version. Do not request `qe-verify` until the feature is complete.
 
 If you plan to incrementally add functionality to Nightly over a number of release cycles, then you can use a single `meta` bug to keep track of functionality, but don't promote the feature to `Beta`.
 
-If you intend to implement functionality over a number of Beta and Release cycles, then each set of functionality should be treated as a separate `[meta]` bug subject to the process described in this document.
+If you intend to implement functionality over a number of Beta and Release cycles, then the tracking/meta bug should not be marked as FIXED VERIFIED until the feature is completed.
 
 #### What about gradual rollout of features
 
@@ -154,4 +155,5 @@ If you intend to roll out the feature gradually, then the rollout should be trac
 
 - Open bugs for features behind preferences
 - Open bugs for features behind preferences landed but not QAed
+- Bugs for features in upcoming release
 - Bugs for features which have been disabled 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -60,7 +60,7 @@ If the current values of the flag were:
 
 - `release60`
 - `beta61`
-- `beta62`
+- `nightly62`
 
 on merge day we would add
 
@@ -78,7 +78,7 @@ _Example_
 
 - `---`
 - `off`
-- `esr59`
+- `esr52`
 - `esr60`
 
 ### Example

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -68,6 +68,17 @@ on merge day we would add
 
 and disable (but not delete) `release60`, `beta61`, and `nightly62`.
 
+#### ESR
+
+For tracking the feature in ESR, we create a `behind-pref-esr` status flag. It will be kept up with the values of the current and previous ESR releases. 
+
+_Example_
+
+- `---`
+- `off`
+- `esr59`
+- `esr60`
+
 ### Example
 
 A bug is filed, "Make Tabby Cats the default new tab experience." And the team developing this (engineering and product) decide that this should be controlled behind a preference, `browser.newtabpage.default.tabbycat`. The developers break the work for this feature down into three bugs.
@@ -103,6 +114,8 @@ Once the feature has been verfied by QA then:
 - the `behind-pref` flag is updated to `betaNN+1` 
 
 The feature now *rides the trains* to release, and on merge day, `behind-pref` is set to `nightlyNN`. The bug is then considered completed. 
+
+When the next ESR is released, the `behind-pref-esr` field should be set to the version where it was relased. 
 
 ### Questions 
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -48,7 +48,7 @@ Where NN is the current relase version of Firefox.
   <dd>The feature is enabled by default in Firefox NN (Release), Beta and Nightly</dd>
   <dt>betaNN+1</dt>
   <dd>The feature is enabled by default in FirefoxNN+1 (Beta), and Nightly, but not Release</dd>
-  <dt>nightlyNN+2<dt>
+  <dt>nightlyNN+2</dt>
   <dd>The feature is enabled by default in FirefoxNN+2 (Nightly), but neither Beta or Release</dd>
 </dl>
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -4,6 +4,8 @@ Product and release need to track bugs whose visibility is controlled through a 
 
 ### Policy
 
+_For any feature or fix controlled by a preference flag in Firefox, there should be a single bug (e.g. a meta bug) to track its release. If the feature requires multiple bugs/patches then this should be a `meta` bug._
+
 _The bug which tracks a feature or fix that is controlled by a flag in Firefox preferences must do the following:_
 
 _It **must** use the `behind-pref` flag. The leads for the feature would need to update the flags appropriately until the bug is closed._

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -143,6 +143,10 @@ If you plan to incrementally add functionality to Nightly over a number of relea
 
 If you intend to implement functionality over a number of Beta and Release cycles, then each set of functionality should be treated as a separate `[meta]` bug subject to the process described in this document.
 
+#### What about gradual rollout of features
+
+If you intend to roll out the feature gradually, then the rollout should be tracked in the feature bug's comments. If the the rollout percentage is controlled by a preference, then changes to that preference should be blockers of the the feature bug.
+
 ### Tracking queries
 
 - Open bugs for features behind preferences

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -105,7 +105,7 @@ Before the feature can graduate to Beta, it must be verified by QA.
 
 If the feature does not pass testing then QA should file bugs blocking the `[meta]` bug for the feature. QA and the development team must confer and decide if the feature will be disabled in Nightly, or allowed to be kept on while bugs are fixed. This will depend on risk and severity of the bugs found. 
 
-If it's decided to disable the feature, then it should be turned off in the nightly build and the `behind-pref` flag set to `off`. The bug's comments should explain why that decision was released. Once the defects have been resolved, then `behind-pref` can be reset to `nightlyNN+2`.
+If it's decided to disable the feature, then it should be turned off in the nightly build and the `behind-pref` flag set to `off`. The bug's comments should explain how that decision was reached. Once the defects have been resolved, then `behind-pref` can be reset to `nightlyNN+2`.
 
 Once the feature has been verfied by QA then:
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -127,6 +127,10 @@ The main bug's `behind-pref` value should be reset to the releases it's still on
 
 The bug to turn off the feature must be a dependency of the main bug.
 
+#### What about bugs found in a feature after release
+
+These bugs do not need the `behind-pref` flag. If it's decided that the feature should be turned off until the bug or bugs are fixed, then these bugs should block the original feature tracking bug.
+
 #### What if we want to hold a feature over a release cycle and not promote it?
 
 On merge day, the `behind-pref` flag would retain it's earlier value, and remain preffed off in other versions.

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -95,7 +95,6 @@ As the feature is developed and the individual patches implement it land, it's k
 
 The lead for the feature–which may be an engineer, a program manager, or a product manager–must notify the Nightly Release Manager before enabling it.
 
-- The `[meta]` bug's status is moved to RESOLVED and resolution to FIXED.
 - The bug's `behind-pref` flag is set to `nightlyNN+2` to indicate it's now available in nightly
 - The `qe-verify` flag is set to ?, requesting QA's attention
 
@@ -103,7 +102,6 @@ Before the feature can graduate to Beta, it must be verified by QA.
 
 - QA agrees to take on verfication, setting `qe-verify` to `+`
 - The feature is tested on nightly and confirmed to work as specified (implicit here is the feature team's involvement in creating a test plan)
-- QA moves the bug's status to VERIFIED
 
 If the feature does not pass testing then QA should file bugs blocking the `[meta]` bug for the feature. QA and the development team must confer and decide if the feature will be disabled in Nightly, or allowed to be kept on while bugs are fixed. This will depend on risk and severity of the bugs found. 
 
@@ -111,7 +109,7 @@ If it's decided to disable the feature, then it should be turned off in the nigh
 
 Once the feature has been verfied by QA then:
 
-- The bug for the feature should be updated to VERIFIED FIXED
+- QA moves the bug's status to VERIFIED and resolution to FIXED
 - The bug should be enabled in Beta once Release Management approves
 - the `behind-pref` flag is updated to `betaNN+1` 
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -6,63 +6,124 @@ Product and release need to track bugs whose visibility is controlled through a 
 
 _A bug for a feature/fix that is controlled by a flag in Firefox preferences must do the following:_
 
-_The bug **must** have the `behind-pref` flag set to +._
+_The bug **must** use the `behind-pref` flag. The leads for the feature would need to update the flags appropriately until the bug is closed._
 
-_Any bug controlled by a flag **must** be added to the Firefox Feature Trello board._
+_Any bug controlled by the `behind-pref` flag **must** be added to the Firefox Feature Trello board._
 
 _The bug **must** state in a comment or the summary which preference will be used to manage visibility._
 
-_The bug **must** request the `qe-verify` flag (setting it to `?`) and the bug **must** be verfified (Status: RESOVED, Resolution: VERIFIED) by QA once they have accepted the `qe-verify` request (setting the flag to `+`)._
+_The bug **must** request the `qe-verify` flag (setting it to `?`) and the bug **must** be verfified (Status: RESOLVED, Resolution: VERIFIED) by QA once they have accepted the `qe-verify` request (setting the flag to `+`) before the feature can be promoted to Beta._
 
-_When it is time to release the feature on a channel, a bug, dependent on the feature bug, should be filed to flip the pref._
+_The bug's severity **must** be set to `enhancement`._
 
-### Questions
+_The Release Managers for each train must consent to the feature being enabled._
 
-> _NB: this is not the current practice for feature visiblity and under discussion._
->
-> In current practice, the preference enabling the feature is set on, and compiler flags are used to turn it off in non-Nightly  builds.
->
-> There is also discussion of moving feature visibility out of the preference system and into a separate 'feature flags' system more consistent with how other products and projects enable features.
+_QA **must** sign off on the feature before it is enabled in Beta._
+
+_Any released feature **must** have a value of the parent bug's `behind-pref` flag set to the version where the feature was released, and have a state of RESOLVED and resolution VERIFED._
+
+### The `behind-pref` flag
+
+The `behind-pref` flag is a multi-valued release-status flag with the values
+
+- `---`
+- `in-progress`
+- `off`
+- `releaseNN`
+- `betaNN+1`
+- `nightlyNN+2`
+
+Where NN is the current relase version of Firefox. 
+
+#### Values and Meanings
+
+<dl>
+  <dt>---</dt>
+  <dd>This is not a feature that is preffed-off</dd>
+  <dt>in-progress</dt>
+  <dd>One or more bugs implementing the feature are still in progress and the feature is not available in any release</dd>
+  <dt>off</dt>
+  <dd>The code for this feature has landed in m-c but the feature is preffed-off in all releases</dd>
+  <dt>releaseNN</dt>
+  <dd>The feature is enabled by default in Firefox NN (Release), Beta and Nightly</dd>
+  <dt>betaNN+1</dt>
+  <dd>The feature is enabled by default in FirefoxNN+1 (Beta), and Nightly, but not Release</dd>
+  <dt>nightlyNN+2<dt>
+  <dd>The feature is enabled by default in FirefoxNN+2 (Nightly), but neither Beta or Release</dd>
+</dl>
+
+#### Maintenance 
+
+If the current values of the flag were:
+
+- `release60`
+- `beta61`
+- `beta62`
+
+on merge day we would add
+
+- `release61`
+- `beta62`
+- `nightly63`
+
+and disable (but not delete) `release60`, `beta61`, and `nightly62`.
 
 ### Example
 
-A bug is filed, "Make Tabby Cats the default new tab experience." 
+A bug is filed, "Make Tabby Cats the default new tab experience." And the team developing this (engineering and product) decide that this should be controlled behind a preference, `browser.newtabpage.default.tabbycat`. The developers break the work for this feature down into three bugs.
 
-It's decided that this should be controlled behind a preference, `browser.newtabpage.default.tabbycat`:
+- The bug's summary is updated to `[meta] Make Tabby Cats the default new tab experience`
+- A comment is filed listing the name of the preference
+- The `behind-pref` flag is set to `in-progress`
+- The bug's severity is set to `enhancement`
+- The three implementation bugs should be marked as blocking the `[meta]` bug for the new feature
 
-*   A comment is filed listing the name of the preference
-*   The `behind-pref` flag is set to +
-*   The `qe-verify` flag is set to ?, requesting QA's attention
+As the feature is developed and the individual patches implement it land, it's kept off by compiler directives, the pref, or both. As these land, and are not backed out, these bugs can be marked RESOLVED FIXED.
 
-![Screenshot of Bugzilla with tracking pane open for editing displaying the behind-pref and qe-verify flags](/public/images/feature-flags-editing-in-bmo.png)
+Once the dependent bugs have been resolved, the feature can be enabled in nightly. The lead for the feature–which may be an engineer, a program manager, or a product manager–must notify the Nightly Release Manager before enabling it.
 
-By default, the preference enabling the feature **should not** be set.
+- The `[meta]` bug's status is moved to RESOLVED and resolution to FIXED.
+- The bug's `behind-pref` flag is set to `nightlyNN+2` to indicate it's now available in nightly
+- The `qe-verify` flag is set to ?, requesting QA's attention
 
-A patch lands in mozilla-central with the code for the feature controlled by the preference, then:
+Before the feature can graduate to Beta, it must be verified by QA. 
 
-*   The bug's status is moved to RESOLVED and resolution to FIXED.
-*   QA agrees to take on verfication, setting `qe-verify` to `+`
-*   The feature is tested with and without the flag set and confirmed to work
-*   QA moveds the bug's resolution to VERIFIED
-*   Otherwise the patch is backed out to be landed again later, and the bug REOPENED
+- QA agrees to take on verfication, setting `qe-verify` to `+`
+- The feature is tested on nightly and confirmed to work as specified (implicit here is the feature team's involvement in creating a test plan)
+- QA moves the bug's resolution to VERIFIED
 
+If the feature does not pass testing then QA should file bugs blocking the `[meta]` bug for the feature. QA and the development team must confer and decide if the feature will be disabled in Nightly, or allowed to be kept on while bugs are fixed. This will depend on risk and severity of the bugs found. 
 
-Once the bug for the feature has reached RESOLVED VERIFIED, then the lead for the feature which may be an engineer, a program manager, or a product manager must confirm with the Nightly Release Manager, and then enable it.
+If it's decided to disable the feature, then it should be turned off in the nightly build and the `behind-pref` flag set to `off`. The bug's comments should explain why that decision was released. Once the defects have been resolved, then `behind-pref` can be reset to `nightlyNN+2`.
 
-*   The patch to flip the pref on should be attached to the "Make Tabby Cats the new default tab experience" bug
+Once the feature has been verfied by QA then:
 
-If a decision is made to uplift the feature to another release, then RelMan and product must decide when to enable the feature. If they do decide to enable it then:
+- The bug for the feature should be moved to RESOLVED VERIFIED status
+- The bug should be enabled in Beta once Release Management approves
+- the `behind-pref` flag is updated to `betaNN+1` 
 
-*   The patch to turn the pref on which has been attached to the "Make Tabby Cats the new default tab experience" bug should be requested to be uplifted to the appropriate train
+The feature now *rides the trains* to release, and on merge day, `behind-pref` is set to `nightlyNN`. The bug is then considered completed. 
 
-Once we reach code freeze for the the new release, RelMan and product must decide if the feature goes out with the flag turned on, then:
+### Questions 
 
-*   A bug is filed to turn off the feature. The bug **must** be marked as blocking release.
+#### What if we turn off the feature in the main release?
 
-If the release goes out with the preference for the feature turned off, another bug **must** be filed to turn the preference on.
+The main bug's `behind-pref` value should be reset to the releases it's still on, `betaNN+1` or `nightlyNN+2`; or to `off`, and the bug's status set to REOPENED.
+
+The bug to turn off the feature must be a dependency of the main bug.
+
+#### What if we want to hold a feature over a release cycle and not promote it?
+
+On merge day, the `behind-pref` flag would change from the previous to the new Beta or Nightly value, and remain preffed off in other versions.
+
+#### What if I want to enable parts of my feature in Nightly?
+
+If your feature is incomplete, but some functionality is avalable, then mark `behind-pref` as `nightlyNN+2`. Do not request `qe-verify` until the feature is complete.
+
+If you intend to release functionality over a number of releases, then each set of functionality should be treated as a separate `[meta]` bug subject to the process described in this document.
 
 ### Tracking queries
 
-*   Open bugs for features behind preferences
-*   Open bugs for features behind preferences landed but not QAed
-*   Open bugs for features behind preferences blocking release
+- Open bugs for features behind preferences
+- Open bugs for features behind preferences landed but not QAed
+- Bugs for features which have been disabled 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -100,11 +100,10 @@ As the feature is developed and the individual patches implement it land, it's k
 The lead for the feature–which may be an engineer, a program manager, or a product manager–must notify the Nightly Release Manager before enabling it.
 
 - The bug's `behind-pref` flag is set to `nightlyNN` where NN is the current version of nightly to indicate it's now available in nightly
-- The `qe-verify` flag is set to ?, requesting QA's attention
+- The `qe-verify` flag is set to +, requesting QA's attention
 
 Before the feature can graduate to Beta, it must be verified by QA. 
 
-- QA agrees to take on verfication, setting `qe-verify` to `+`
 - The feature is tested on nightly and confirmed to work as specified (implicit here is the feature team's involvement in creating a test plan)
 
 If the feature does not pass testing then QA should file bugs blocking the `[meta]` bug for the feature. QA and the development team must confer and decide if the feature will be disabled in Nightly, or allowed to be kept on while bugs are fixed. This will depend on risk and severity of the bugs found. 
@@ -113,9 +112,12 @@ If it's decided to disable the feature, then it should be turned off in the nigh
 
 Once the feature has been verfied by QA then:
 
-- QA moves the bug's status to VERIFIED and resolution to FIXED
 - The bug should be enabled in Beta once Release Management approves
 - the `behind-pref` flag is updated to `releaseNN` where NN is the next release. 
+
+Once the patch for the bug to enable in Beta lands:
+
+- QA moves the bug's status to VERIFIED and resolution to FIXED
 
 The feature now *rides the trains* to release. The bug is then considered completed. 
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -93,7 +93,7 @@ A bug is filed, "Make Tabby Cats the default new tab experience." And the team d
 
 As the feature is developed and the individual patches implement it land, it's kept off by compiler directives, the pref, or both. As these land, and are not backed out, these bugs can be marked RESOLVED FIXED.
 
-Once the dependent bugs have been resolved, the feature can be enabled in nightly. The lead for the feature–which may be an engineer, a program manager, or a product manager–must notify the Nightly Release Manager before enabling it.
+The lead for the feature–which may be an engineer, a program manager, or a product manager–must notify the Nightly Release Manager before enabling it.
 
 - The `[meta]` bug's status is moved to RESOLVED and resolution to FIXED.
 - The bug's `behind-pref` flag is set to `nightlyNN+2` to indicate it's now available in nightly
@@ -129,13 +129,15 @@ The bug to turn off the feature must be a dependency of the main bug.
 
 #### What if we want to hold a feature over a release cycle and not promote it?
 
-On merge day, the `behind-pref` flag would change from the previous to the new Beta or Nightly value, and remain preffed off in other versions.
+On merge day, the `behind-pref` flag would retain it's earlier value, and remain preffed off in other versions.
 
 #### What if I want to enable parts of my feature in Nightly?
 
 If your feature is incomplete, but some functionality is avalable, then mark `behind-pref` as `nightlyNN+2`. Do not request `qe-verify` until the feature is complete.
 
-If you intend to release functionality over a number of releases, then each set of functionality should be treated as a separate `[meta]` bug subject to the process described in this document.
+If you plan to incrementally add functionality to Nightly over a number of release cycles, then you can use a single `meta` bug to keep track of functionality, but don't promote the feature to `Beta`.
+
+If you intend to implement functionality over a number of Beta and Release cycles, then each set of functionality should be treated as a separate `[meta]` bug subject to the process described in this document.
 
 ### Tracking queries
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -47,25 +47,28 @@ Where NN is the current relase version of Firefox.
   <dt>off</dt>
   <dd>The code for this feature has landed in m-c but the feature is preffed-off in all releases</dd>
   <dt>releaseNN</dt>
-  <dd>The feature is enabled by default in Firefox NN (Release), Beta and Nightly</dd>
-  <dt>betaNN+1</dt>
-  <dd>The feature is enabled by default in FirefoxNN+1 (Beta), and Nightly, but not Release</dd>
-  <dt>nightlyNN+2</dt>
-  <dd>The feature is enabled by default in FirefoxNN+2 (Nightly), but neither Beta or Release</dd>
+  <dd>Feature was enabled in or will ride the trains to Release NN</dd>
+  <dt>betaNN</dt>
+  <dd>The feature was enabled in Beta NN and Nightly but not riding train to Release</dd>
+  <dt>nightlyNN</dt>
+  <dd>The feature was enabled in Nightly NN only</dd>
 </dl>
 
 #### Maintenance 
 
-If the current values of the flag were:
+If, as of release version 60, current values of the flag were:
 
 - `release60`
+- `release61`
+- `release62`
 - `beta61`
+- `beta62`
 - `nightly62`
 
 on merge day we would add
 
-- `release61`
-- `beta62`
+- `release63`
+- `beta63`
 - `nightly63`
 
 and disable (but not delete) `release60`, `beta61`, and `nightly62`.
@@ -83,19 +86,19 @@ _Example_
 
 ### Example
 
-A bug is filed, "Make Tabby Cats the default new tab experience." And the team developing this (engineering and product) decide that this should be controlled behind a preference, `browser.newtabpage.default.tabbycat`. The developers break the work for this feature down into three bugs.
+A bug is filed, "Make Tabby Cats the default new tab experience." And the team developing this (engineering and product) decide that this should be controlled behind a preference, `browser.newtabpage.default.tabbycat`. The developers break the work for this feature down into three bugs. A fourth bug will be used to track the preference flag.
 
 - The bug's summary is updated to `[meta] Make Tabby Cats the default new tab experience`
 - A comment is filed listing the name of the preference
 - The `behind-pref` flag is set to `in-progress`
 - The bug's severity is set to `enhancement`
-- The three implementation bugs should be marked as blocking the `[meta]` bug for the new feature
+- The three implementation bugs and the pref bug should be marked as blocking the `[meta]` bug for the new feature
 
 As the feature is developed and the individual patches implement it land, it's kept off by compiler directives, the pref, or both. As these land, and are not backed out, these bugs can be marked RESOLVED FIXED.
 
 The lead for the feature–which may be an engineer, a program manager, or a product manager–must notify the Nightly Release Manager before enabling it.
 
-- The bug's `behind-pref` flag is set to `nightlyNN+2` to indicate it's now available in nightly
+- The bug's `behind-pref` flag is set to `nightlyNN` where NN is the current version of nightly to indicate it's now available in nightly
 - The `qe-verify` flag is set to ?, requesting QA's attention
 
 Before the feature can graduate to Beta, it must be verified by QA. 
@@ -105,15 +108,17 @@ Before the feature can graduate to Beta, it must be verified by QA.
 
 If the feature does not pass testing then QA should file bugs blocking the `[meta]` bug for the feature. QA and the development team must confer and decide if the feature will be disabled in Nightly, or allowed to be kept on while bugs are fixed. This will depend on risk and severity of the bugs found. 
 
-If it's decided to disable the feature, then it should be turned off in the nightly build and the `behind-pref` flag set to `off`. The bug's comments should explain how that decision was reached. Once the defects have been resolved, then `behind-pref` can be reset to `nightlyNN+2`.
+If it's decided to disable the feature, then it should be turned off in the nightly build and the `behind-pref` flag set to `off`. The bug's comments should explain how that decision was reached. Once the defects have been resolved, then `behind-pref` can be reset to `nightlyNN`.
 
 Once the feature has been verfied by QA then:
 
 - QA moves the bug's status to VERIFIED and resolution to FIXED
 - The bug should be enabled in Beta once Release Management approves
-- the `behind-pref` flag is updated to `betaNN+1` 
+- the `behind-pref` flag is updated to `releaseNN` where NN is the next release. 
 
-The feature now *rides the trains* to release, and on merge day, `behind-pref` is set to `nightlyNN`. The bug is then considered completed. 
+The feature now *rides the trains* to release. The bug is then considered completed. 
+
+If it's decided to hold the feature out of the next release and let Beta users try it out, then the `behind-pref` flag is set to `betaNN` where NN is the next beta. Once the decision is made to let the feature ride the trains, then it is updated to `releaseNN`.
 
 When the next ESR is released, the `behind-pref-esr` field should be set to the version where it was relased. 
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -4,19 +4,19 @@ Product and release need to track bugs whose visibility is controlled through a 
 
 ### Policy
 
-_A bug for a feature/fix that is controlled by a flag in Firefox preferences must do the following:_
+_The bug which tracks a feature or fix that is controlled by a flag in Firefox preferences must do the following:_
 
-_The bug **must** use the `behind-pref` flag. The leads for the feature would need to update the flags appropriately until the bug is closed._
+_It **must** use the `behind-pref` flag. The leads for the feature would need to update the flags appropriately until the bug is closed._
 
-_Any bug controlled by the `behind-pref` flag **must** be added to the Firefox Feature Trello board._
+_It **should** be added to the Firefox Feature Trello board._
 
-_The bug **must** state in a comment or the summary which preference will be used to manage visibility._
+_It **must** state in a comment or the summary which preference will be used to manage visibility._
 
-_The bug **must** request the `qe-verify` flag (setting it to `?`) and the bug **must** be verfified (Status: RESOLVED, Resolution: VERIFIED) by QA once they have accepted the `qe-verify` request (setting the flag to `+`) before the feature can be promoted to Beta._
+_It **must** request the `qe-verify` flag (setting it to `?`) and the bug **must** be verfified (Status: RESOLVED, Resolution: VERIFIED) by QA once they have accepted the `qe-verify` request (setting the flag to `+`) before the feature can be promoted to Beta._
 
-_The bug's severity **must** be set to `enhancement`._
+_The severity of the bug tracking the feature **must** be set to `enhancement`._
 
-_The Release Managers for each train must consent to the feature being enabled._
+_The Release Managers for each train must consent to the feature being enabled on that train._
 
 _QA **must** sign off on the feature before it is enabled in Beta._
 

--- a/policy/feature-flags.md
+++ b/policy/feature-flags.md
@@ -22,7 +22,7 @@ _The Release Managers for each train must consent to the feature being enabled o
 
 _QA **must** sign off on the feature before it is enabled in Beta._
 
-_Any released feature **must** have a value of the parent bug's `behind-pref` flag set to the version where the feature was released, and have a state of RESOLVED and resolution VERIFED._
+_Any released feature **must** have a value of the parent bug's `behind-pref` flag set to the version where the feature was released, and have a state of VERIFIED and resolution FIXED._
 
 ### The `behind-pref` flag
 
@@ -103,7 +103,7 @@ Before the feature can graduate to Beta, it must be verified by QA.
 
 - QA agrees to take on verfication, setting `qe-verify` to `+`
 - The feature is tested on nightly and confirmed to work as specified (implicit here is the feature team's involvement in creating a test plan)
-- QA moves the bug's resolution to VERIFIED
+- QA moves the bug's status to VERIFIED
 
 If the feature does not pass testing then QA should file bugs blocking the `[meta]` bug for the feature. QA and the development team must confer and decide if the feature will be disabled in Nightly, or allowed to be kept on while bugs are fixed. This will depend on risk and severity of the bugs found. 
 
@@ -111,7 +111,7 @@ If it's decided to disable the feature, then it should be turned off in the nigh
 
 Once the feature has been verfied by QA then:
 
-- The bug for the feature should be moved to RESOLVED VERIFIED status
+- The bug for the feature should be updated to VERIFIED FIXED
 - The bug should be enabled in Beta once Release Management approves
 - the `behind-pref` flag is updated to `betaNN+1` 
 


### PR DESCRIPTION
Convert `behind-pref` to a multi-valued release status flag, clarify process, and describe the `[meta]` bug case 

This resolves issues #4, and #5.