### PR TITLE
Bring back the anchor

### DIFF
--- a/_policies/triage-bugzilla.md
+++ b/_policies/triage-bugzilla.md
@@ -47,7 +47,7 @@ Weekly or More Frequently (depending on the component) find [un-triaged bugs in 
 
 For each bug decide priority (you can override what's already been set, as a triage lead, you are the decider.)
 
-| Priority | Description |
+| [Priority](#how-do-you-triage) | Description |
 | ---: | --- |
 | -- | No decision |
 | P1 | Fix in the current release cycle (nightly) |


### PR DESCRIPTION
Used by the bot. example: https://bugzilla.mozilla.org/show_bug.cgi?id=1534749#c4